### PR TITLE
Rename remaining `colur` references to `colorTime`

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -1,32 +1,32 @@
 const { contextBridge, ipcRenderer } = require("electron");
 
 contextBridge.exposeInMainWorld("colorTime", {
-  getColor: () => ipcRenderer.invoke("colur:getColor"),
+  getColor: () => ipcRenderer.invoke("colorTime:getColor"),
   onColor: (cb) => {
     const handler = (_e, payload) => cb(payload);
-    ipcRenderer.on("colur:color", handler);
-    return () => ipcRenderer.removeListener("colur:color", handler);
+    ipcRenderer.on("colorTime:color", handler);
+    return () => ipcRenderer.removeListener("colorTime:color", handler);
   },
 
-  getRange: () => ipcRenderer.invoke("colur:getRange"),
-  setRange: (range) => ipcRenderer.invoke("colur:setRange", range),
+  getRange: () => ipcRenderer.invoke("colorTime:getRange"),
+  setRange: (range) => ipcRenderer.invoke("colorTime:setRange", range),
   onRange: (cb) => {
     const handler = (_e, r) => cb(r);
-    ipcRenderer.on("colur:range", handler);
-    return () => ipcRenderer.removeListener("colur:range", handler);
+    ipcRenderer.on("colorTime:range", handler);
+    return () => ipcRenderer.removeListener("colorTime:range", handler);
   },
 
   onFocusRange: (cb) => {
     const handler = () => cb();
-    ipcRenderer.on("colur:focusRange", handler);
-    return () => ipcRenderer.removeListener("colur:focusRange", handler);
+    ipcRenderer.on("colorTime:focusRange", handler);
+    return () => ipcRenderer.removeListener("colorTime:focusRange", handler);
   },
 
-  getMyColors: () => ipcRenderer.invoke("colur:getMyColors"),
-  addMyColor: (name) => ipcRenderer.invoke("colur:addMyColor", name),
+  getMyColors: () => ipcRenderer.invoke("colorTime:getMyColors"),
+  addMyColor: (name) => ipcRenderer.invoke("colorTime:addMyColor", name),
   onMyColors: (cb) => {
     const handler = (_e, items) => cb(items);
-    ipcRenderer.on("colur:myColors", handler);
-    return () => ipcRenderer.removeListener("colur:myColors", handler);
+    ipcRenderer.on("colorTime:myColors", handler);
+    return () => ipcRenderer.removeListener("colorTime:myColors", handler);
   },
 });

--- a/electron/tray/menubar.cjs
+++ b/electron/tray/menubar.cjs
@@ -20,7 +20,7 @@ async function createMenubarApp() {
   let range = normalizeRange({ min: 30, max: 225 });
 
   const broadcastRange = () => {
-    if (win && !win.isDestroyed()) win.webContents.send("colur:range", range);
+    if (win && !win.isDestroyed()) win.webContents.send("colorTime:range", range);
   };
 
   const refreshNow = () => {
@@ -29,7 +29,7 @@ async function createMenubarApp() {
 
     if (tray) tray.setImage(coloredCircleImage(rgb));
     if (win && !win.isDestroyed())
-      win.webContents.send("colur:color", lastPayload);
+      win.webContents.send("colorTime:color", lastPayload);
 
     updateTrayMenu(win?.isVisible?.() ?? false);
   };
@@ -125,9 +125,9 @@ async function createMenubarApp() {
   function broadcastMyColors() {
     const payload = buildMyColorsPayload();
     if (win && !win.isDestroyed())
-      win.webContents.send("colur:myColors", payload);
+      win.webContents.send("colorTime:myColors", payload);
     if (myColorsWin && !myColorsWin.isDestroyed())
-      myColorsWin.webContents.send("colur:myColors", payload);
+      myColorsWin.webContents.send("colorTime:myColors", payload);
   }
 
   function addMyColorByName(name) {
@@ -326,7 +326,7 @@ async function createMenubarApp() {
 
       if (tray) tray.setImage(coloredCircleImage(rgb));
       if (win && !win.isDestroyed())
-        win.webContents.send("colur:color", lastPayload);
+        win.webContents.send("colorTime:color", lastPayload);
 
       setTimeout(tick, 1000 - (Date.now() % 1000));
     };
@@ -336,22 +336,22 @@ async function createMenubarApp() {
   createWindow();
 
   // ---- IPC ----
-  ipcMain.handle("colur:getColor", () => {
+  ipcMain.handle("colorTime:getColor", () => {
     return lastPayload || { rgb: currentColor(range), ts: Date.now() };
   });
 
-  ipcMain.handle("colur:getRange", () => range);
+  ipcMain.handle("colorTime:getRange", () => range);
 
-  ipcMain.handle("colur:setRange", (_evt, next) => {
+  ipcMain.handle("colorTime:setRange", (_evt, next) => {
     setRange(next);
     return range;
   });
 
-  ipcMain.handle("colur:getMyColors", () => {
+  ipcMain.handle("colorTime:getMyColors", () => {
     return buildMyColorsPayload();
   });
 
-  ipcMain.handle("colur:addMyColor", (_evt, name) => {
+  ipcMain.handle("colorTime:addMyColor", (_evt, name) => {
     addMyColorByName(name);
     return buildMyColorsPayload();
   });

--- a/src/config/types/colorTime.ts
+++ b/src/config/types/colorTime.ts
@@ -1,6 +1,6 @@
 const noopUnsub = () => {};
 
-export const colur = {
+export const colorTime = {
   getColor: async (): Promise<ColorPayload | null> => {
     const p = await window.colorTime?.getColor?.();
     return p ?? null;

--- a/src/ts/ColorScreen.tsx
+++ b/src/ts/ColorScreen.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { ColorsToRGB } from "../colors/ColorList";
 import "../css/ColorScreen.css";
-import { colur } from "../config/types/colorTime";
+import { colorTime } from "../config/types/colorTime";
 
 const toHex = ({ r, g, b }: RGB) =>
   `#${[r, g, b].map((n) => n.toString(16).padStart(2, "0")).join("")}`.toUpperCase();
@@ -14,11 +14,11 @@ export default function ColorScreen() {
   const [range, setRange] = useState<ColorRange>({ min: 25, max: 230 });
 
   useEffect(() => {
-    colur.getColor().then(setPayload);
-    const unsubColor = colur.onColor(setPayload);
+    colorTime.getColor().then(setPayload);
+    const unsubColor = colorTime.onColor(setPayload);
 
-    colur.getRange().then((r) => r && setRange(r));
-    const unsubRange = colur.onRange((r) => r && setRange(r));
+    colorTime.getRange().then((r) => r && setRange(r));
+    const unsubRange = colorTime.onRange((r) => r && setRange(r));
 
     return () => {
       unsubColor();
@@ -43,7 +43,7 @@ export default function ColorScreen() {
 
   const applyRange = (next: ColorRange) => {
     setRange(next);
-    colur.setRange(next);
+    colorTime.setRange(next);
   };
 
   const onMinChange = (v: number) => {

--- a/src/ts/MyColorsScreen.tsx
+++ b/src/ts/MyColorsScreen.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import "../css/MyColorsScreen.css";
-import { colur } from "../config/types/colorTime";
+import { colorTime } from "../config/types/colorTime";
 
 const clamp = (n: number, lo: number, hi: number) =>
   Number.isFinite(n) ? Math.min(hi, Math.max(lo, n)) : lo;
@@ -12,11 +12,11 @@ export default function MyColorsScreen() {
   const [items, setItems] = useState<MyColor[]>([]);
 
   useEffect(() => {
-    const unsub = colur.onMyColors((next: MyColor[]) => {
+    const unsub = colorTime.onMyColors((next: MyColor[]) => {
       setItems(Array.isArray(next) ? next : []);
     });
 
-    colur.getMyColors().then(setItems);
+    colorTime.getMyColors().then(setItems);
 
     return () => {
       unsub();


### PR DESCRIPTION
### Motivation
- Finish renaming leftover `colur`/`Colur` identifiers to a consistent `colorTime` API so frontend, preload and main process IPC channels match and avoid runtime mismatches. 
- Keep the public frontend API and Electron IPC naming clear and aligned with the repository's `ColorTime` app name.

### Description
- Export name changed from `colur` to `colorTime` in `src/config/types/colorTime.ts`. 
- React screens updated to import and call `colorTime` instead of `colur` (`ColorScreen.tsx` and `MyColorsScreen.tsx`). 
- Electron preload bridge updated to invoke and listen on `colorTime:*` IPC channels instead of `colur:*` (`electron/preload.cjs`). 
- Electron menubar/main process updated to send and handle `colorTime:*` IPC messages and broadcasts (`electron/tray/menubar.cjs`). 

### Testing
- Ran `npm run lint` which completed successfully. 
- Ran `npm run build` which completed successfully and produced the `dist` bundle. 
- Verified no remaining `colur`/`Colur` occurrences with `rg -n "colur|Colur"` which returned no results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d662bab10832da0127963e78f8d34)